### PR TITLE
Create slack_team_join.json

### DIFF
--- a/slack_team_join.json
+++ b/slack_team_join.json
@@ -1,0 +1,71 @@
+{
+   "token": "one-long-verification-token",
+   "team_id": "T061EG9R6",
+   "api_app_id": "A0PNCHHK2",
+   "event": {
+      "type": "team_join",
+      "user": {
+         "id": "U07XX2HFGGH",
+         "team_id": "T061EG9R6",
+         "name": "johndoe",
+         "deleted": false,
+         "color": "43761b",
+         "real_name": "John Doe",
+         "tz": "Europe/Belgrade",
+         "tz_label": "Central European Summer Time",
+         "tz_offset": 7200,
+         "profile": {
+            "title": "",
+            "phone": "",
+            "skype": "",
+            "real_name": "John Doe",
+            "real_name_normalized": "John Doe",
+            "display_name": "John Doe",
+            "display_name_normalized": "John Doe",
+            "fields": {},
+            "status_text": "",
+            "status_emoji": "",
+            "status_emoji_display_info": [],
+            "status_expiration": 0,
+            "avatar_hash": "g49495797581",
+            "email": "john@doe.io",
+            "first_name": "John",
+            "last_name": "Doe",
+            "image_24": "https://secure.gravatar.com/avatar/4949579758168ab9e90b303edd096067.jpg?s=24&d=https%3A%2F%2Fa.slack-edge.com%2Fdf10d%2Fimg%2Favatars%2Fava_0014-24.png",
+            "image_32": "https://secure.gravatar.com/avatar/4949579758168ab9e90b303edd096067.jpg?s=32&d=https%3A%2F%2Fa.slack-edge.com%2Fdf10d%2Fimg%2Favatars%2Fava_0014-32.png",
+            "image_48": "https://secure.gravatar.com/avatar/4949579758168ab9e90b303edd096067.jpg?s=48&d=https%3A%2F%2Fa.slack-edge.com%2Fdf10d%2Fimg%2Favatars%2Fava_0014-48.png",
+            "image_72": "https://secure.gravatar.com/avatar/4949579758168ab9e90b303edd096067.jpg?s=72&d=https%3A%2F%2Fa.slack-edge.com%2Fdf10d%2Fimg%2Favatars%2Fava_0014-72.png",
+            "image_192": "https://secure.gravatar.com/avatar/4949579758168ab9e90b303edd096067.jpg?s=192&d=https%3A%2F%2Fa.slack-edge.com%2Fdf10d%2Fimg%2Favatars%2Fava_0014-192.png",
+            "image_512": "https://secure.gravatar.com/avatar/4949579758168ab9e90b303edd096067.jpg?s=512&d=https%3A%2F%2Fa.slack-edge.com%2Fdf10d%2Fimg%2Favatars%2Fava_0014-512.png",
+            "status_text_canonical": "",
+            "team": "T061RG9R6"
+         },
+         "is_admin": false,
+         "is_owner": false,
+         "is_primary_owner": false,
+         "is_restricted": false,
+         "is_ultra_restricted": false,
+         "is_bot": false,
+         "is_app_user": false,
+         "updated": 1355517523,
+         "is_email_confirmed": true,
+         "who_can_share_contact_card": "EVERYONE",
+         "presence": "away"
+      },
+      "cache_ts": 1355517523,
+      "event_ts": "1355517523.010700"
+   },
+   "type": "event_callback",
+   "event_id": "Ev0PV52K21",
+   "event_time": 1355517523,
+   "authorizations": [
+      {
+         "enterprise_id": null,
+         "team_id": "T061EG9R6",
+         "user_id": "U07XX2HFE7H",
+         "is_bot": false,
+         "is_enterprise_install": false
+      }
+   ],
+   "is_ext_shared_channel": false
+}


### PR DESCRIPTION
Adding example payload for `team_join` event. User, team and other identifiers obfuscated or used from the existing slack example for channel message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new event payload for Slack team join events, including verification tokens, event metadata, and comprehensive user profile information such as email, avatar details, timezone, and role flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->